### PR TITLE
PR for adding first basic script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # Spammer WDL
 
+# 1 - Introduction
+
 The WDL equivalent of `lifebit-ai/spammer-nf`.
+
+# 2 - Quick start
+
+To generate inputs.json file (rough equivalent of `nextflow.config`):
+```
+$ java -jar ~/cromwell/womtool-53.1.jar inputs main.wdl > inputs.json
+# One can then populate the inputs.json
+```
+
+To run the pipeline:
+```
+$ java -jar ~/cromwell/cromwell-53.1.jar run main.wdl -i inputs.json
+```
 
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ $ java -jar ~/cromwell/womtool-53.1.jar inputs main.wdl > inputs.json
 # One can then populate the inputs.json
 ```
 
+To validate your `main.wdl` syntax (i.e. to check that everything looks ok):
+```
+java -jar ~/cromwell/womtool-53.1.jar validate main.wdl
+
+# If successful, you will see:
+Success!
+```
+
 To run the pipeline:
 ```
 $ java -jar ~/cromwell/cromwell-53.1.jar run main.wdl -i inputs.json

--- a/inputs.json
+++ b/inputs.json
@@ -1,6 +1,8 @@
 {
   "spammer_wdl.task_A.taskATimeBetweenFileCreationInSecs": "0",
   "spammer_wdl.task_A.taskATimeRange": "1-2",
-  "spammer_wdl.task_A.numberFilesFortaskA": "2"
+  "spammer_wdl.task_B.processBWriteToDiskMb": "10",
+  "spammer_wdl.task_A.numberFilesFortaskA": "2",
+  "spammer_wdl.task_B.taskBTimeRange": "2-3"
 }
 

--- a/inputs.json
+++ b/inputs.json
@@ -1,0 +1,6 @@
+{
+  "spammer_wdl.task_A.processATimeBetweenFileCreationInSecs": "0",
+  "spammer_wdl.task_A.processATimeRange": "1-2",
+  "spammer_wdl.task_A.numberFilesForProcessA": "1"
+}
+

--- a/inputs.json
+++ b/inputs.json
@@ -1,6 +1,6 @@
 {
-  "spammer_wdl.task_A.processATimeBetweenFileCreationInSecs": "0",
-  "spammer_wdl.task_A.processATimeRange": "1-2",
-  "spammer_wdl.task_A.numberFilesForProcessA": "1"
+  "spammer_wdl.task_A.taskATimeBetweenFileCreationInSecs": "0",
+  "spammer_wdl.task_A.taskATimeRange": "1-2",
+  "spammer_wdl.task_A.numberFilesFortaskA": "1"
 }
 

--- a/inputs.json
+++ b/inputs.json
@@ -1,6 +1,6 @@
 {
   "spammer_wdl.task_A.taskATimeBetweenFileCreationInSecs": "0",
   "spammer_wdl.task_A.taskATimeRange": "1-2",
-  "spammer_wdl.task_A.numberFilesFortaskA": "1"
+  "spammer_wdl.task_A.numberFilesFortaskA": "2"
 }
 

--- a/main.wdl
+++ b/main.wdl
@@ -17,6 +17,10 @@ version 1.0
 workflow spammer_wdl {
 
   call task_A
+  call task_B {
+      input:
+      input_file = task_A.output_file_1
+  }
 }
 
 
@@ -32,7 +36,7 @@ task task_A {
         Int taskATimeBetweenFileCreationInSecs
     }
     command <<<
-        # Simulate the time the task takes to finish
+        # Simulate the time the tasks takes to finish
         timeToWait=$(shuf -i ~{taskATimeRange} -n 1)
         
         for i in {1..~{numberFilesFortaskA}}
@@ -44,7 +48,32 @@ task task_A {
     >>>
     output{
         Array[File] output_files = glob("*.txt")
+        File output_file_1 = "file_1.txt"
     }
+    runtime {
+        docker:"ubuntu:18.10"
+    }
+}
+
+
+
+# -------
+# Task B
+# -------
+
+task task_B {
+    input {
+        File input_file
+        String taskBTimeRange
+        Int processBWriteToDiskMb 
+    }
+    command <<<
+    # Simulate the time the tasks takes to finish
+    timeToWait=$(shuf -i ~{taskBTimeRange} -n 1)
+    
+    sleep \$timeToWait
+    dd if=/dev/urandom of=newfile bs=1M count=~{processBWriteToDiskMb}
+    >>>
     runtime {
         docker:"ubuntu:18.10"
     }

--- a/main.wdl
+++ b/main.wdl
@@ -33,14 +33,14 @@ task task_A {
     }
     command <<<
         # Simulate the time the processes takes to finish
-        timeToWait=\$(shuf -i ~{processATimeRange} -n 1)
+        timeToWait=$(shuf -i ~{processATimeRange} -n 1)
         
         for i in {1..~{numberFilesForProcessA}}
         do
-            do echo test > file_\${i}.txt
-            sleep ${processATimeBetweenFileCreationInSecs}
+        echo test > file_${i}.txt
+        sleep ~{processATimeBetweenFileCreationInSecs}
         done
-        sleep \$timeToWait
+        sleep $timeToWait
     >>>
     runtime {
         docker:"ubuntu:18.10"

--- a/main.wdl
+++ b/main.wdl
@@ -51,7 +51,7 @@ task task_A {
         File output_file_1 = "file_1.txt"
     }
     runtime {
-        docker:"ubuntu:18.10"
+        docker:"quay.io/lifebitai/ubuntu:18.10"
     }
 }
 
@@ -78,5 +78,4 @@ task task_B {
         docker:"ubuntu:18.10"
     }
 }
-
 

--- a/main.wdl
+++ b/main.wdl
@@ -27,18 +27,18 @@ workflow spammer_wdl {
 
 task task_A {
     input {
-        String processATimeRange
-        Int numberFilesForProcessA
-        Int processATimeBetweenFileCreationInSecs
+        String taskATimeRange
+        Int numberFilesFortaskA
+        Int taskATimeBetweenFileCreationInSecs
     }
     command <<<
-        # Simulate the time the processes takes to finish
-        timeToWait=$(shuf -i ~{processATimeRange} -n 1)
+        # Simulate the time the task takes to finish
+        timeToWait=$(shuf -i ~{taskATimeRange} -n 1)
         
-        for i in {1..~{numberFilesForProcessA}}
+        for i in {1..~{numberFilesFortaskA}}
         do
         echo test > file_${i}.txt
-        sleep ~{processATimeBetweenFileCreationInSecs}
+        sleep ~{taskATimeBetweenFileCreationInSecs}
         done
         sleep $timeToWait
     >>>

--- a/main.wdl
+++ b/main.wdl
@@ -42,6 +42,9 @@ task task_A {
         done
         sleep $timeToWait
     >>>
+    output{
+        Array[File] output_files = glob("*.txt")
+    }
     runtime {
         docker:"ubuntu:18.10"
     }

--- a/main.wdl
+++ b/main.wdl
@@ -25,8 +25,16 @@ workflow spammer_wdl {
 # Task A
 # -------
 
-task task_A{
+task task_A {
+    input {
+        String processATimeRange
+        Int numberFilesForProcessA
+        Int processATimeBetweenFileCreationInSecs
+    }
     command {
-    echo "hello"
+        # Simulate the time the processes takes to finish
+        timeToWait=\$(shuf -i ${processATimeRange} -n 1)
     }
 }
+
+

--- a/main.wdl
+++ b/main.wdl
@@ -75,7 +75,6 @@ task task_B {
     dd if=/dev/urandom of=newfile bs=1M count=~{processBWriteToDiskMb}
     >>>
     runtime {
-        docker:"ubuntu:18.10"
+        docker:"quay.io/lifebitai/ubuntu:18.10"
     }
 }
-

--- a/main.wdl
+++ b/main.wdl
@@ -31,9 +31,19 @@ task task_A {
         Int numberFilesForProcessA
         Int processATimeBetweenFileCreationInSecs
     }
-    command {
+    command <<<
         # Simulate the time the processes takes to finish
-        timeToWait=\$(shuf -i ${processATimeRange} -n 1)
+        timeToWait=\$(shuf -i ~{processATimeRange} -n 1)
+        
+        for i in {1..~{numberFilesForProcessA}}
+        do
+            do echo test > file_\${i}.txt
+            sleep ${processATimeBetweenFileCreationInSecs}
+        done
+        sleep \$timeToWait
+    >>>
+    runtime {
+        docker:"ubuntu:18.10"
     }
 }
 

--- a/main.wdl
+++ b/main.wdl
@@ -1,0 +1,32 @@
+version 1.0
+
+# ========================================================================================
+#                         lifebit-ai/spammer-wdl
+# ========================================================================================
+# lifebit-ai/spammer-wdl pipeline
+# #### Homepage / Documentation
+# https://github.com/lifebit-ai/spammer-wdl
+# ----------------------------------------------------------------------------------------
+
+
+
+# ---------
+# Workflow
+# ---------
+
+workflow spammer_wdl {
+
+  call task_A
+}
+
+
+
+# -------
+# Task A
+# -------
+
+task task_A{
+    command {
+    echo "hello"
+    }
+}


### PR DESCRIPTION
## This PR does the following:

It adds basic `main.wdl` and `inputs.json` files that mimic `lifebit-ai/spammer-nf`.

## Details:

- Made a `main.wdl` which is a workflow of 2 connected tasks: `task_A`, `task_B`. 
- `task_B` takes an output of `task_A`.


## Comments:

- Tried to mimic needs to `lifebit-ai/spammer-nf` but unsure how to parallelise the equivalent of `Channel.from([1] * numberRepetitionsForProcessA)` (see: https://github.com/lifebit-ai/spammer-nf/blob/658cc6dbbc2680a2aafc45bb97e6551839108a00/main.nf#L5). Most likely, some sort of `scatter` WDL syntax will be needed. This means the pipeline does not currently have a `numberRepetitionsForProcessA` mechanism like `lifebit-ai/spammer-nf` has.

- For now, the pipeline is using the exact same container as `lifebit-ai/spammer-nf`:  `ubuntu:18.10`. Not sure one can use `sha` like in Nextflow.

- Will need to add further tasks (`task_C` and `task_D`).


