### PR TITLE
Adding CI testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Install Cromwell
         run: |
+          sudo apt-get install default-jre
           mkdir cromwell && cd cromwell
           wget https://github.com/broadinstitute/cromwell/releases/download/53.1/cromwell-53.1.jar
           wget https://github.com/broadinstitute/cromwell/releases/download/53.1/womtool-53.1.jar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,10 @@ jobs:
       - name: Install Cromwell
         run: |
           sudo apt-get install default-jre
-          mkdir cromwell && cd cromwell
           wget https://github.com/broadinstitute/cromwell/releases/download/53.1/cromwell-53.1.jar
           wget https://github.com/broadinstitute/cromwell/releases/download/53.1/womtool-53.1.jar
       - name: Run lifebit-ai/spammer-wdl
         run: |
-          java -jar ~/cromwell/cromwell-53.1.jar run main.wdl -i inputs.json -o options.json
+          java -jar cromwell-53.1.jar run main.wdl -i inputs.json -o options.json
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Install Cromwell
         run: |
-          sudo apt-get install default-jre
           wget https://github.com/broadinstitute/cromwell/releases/download/53.1/cromwell-53.1.jar
           wget https://github.com/broadinstitute/cromwell/releases/download/53.1/womtool-53.1.jar
       - name: Run lifebit-ai/spammer-wdl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: tests for lifebit-ai/spammer-wdl
+# This workflow is triggered on pushes and PRs to the repository.
+on: [push, pull_request]
+
+jobs:
+  basic_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Cromwell
+        run: |
+          mkdir cromwell && cd cromwell
+          wget https://github.com/broadinstitute/cromwell/releases/download/53.1/cromwell-53.1.jar
+          wget https://github.com/broadinstitute/cromwell/releases/download/53.1/womtool-53.1.jar
+      - name: Run lifebit-ai/spammer-wdl
+        run: |
+          java -jar ~/cromwell/cromwell-53.1.jar run main.wdl -i inputs.json -o options.json
+
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,24 @@ This pipeline is the WDL equivalent of `lifebit-ai/spammer-nf`.
 
 # 2 - Quick start
 
+## Installation instructions and assumptions
+
+Like for `Nextflow` pipelines, one should install `Cromwell` "locally", seperate from the actual pipeline dependencies which will obtained via one or more containers. The installation instructions used to install and run `Cromwell` for the development of this pipeline are as follows:
+
+```
+$ cd
+$ mkdir cromwell && cd cromwell
+$ wget https://github.com/broadinstitute/cromwell/releases/download/53.1/cromwell-53.1.jar
+$ wget https://github.com/broadinstitute/cromwell/releases/download/53.1/womtool-53.1.jar
+```
+
+This means `Cromwell` can be called from anywhere using:
+```
+$ java -jar ~/cromwell/cromwell-53.1.jar [specific command]
+```
+
+Notably, `Cromwell` can also be installed via `conda`.
+
 ## Generate an input.json file
 
 Inputs are to this pipeline are supplied via an `inputs.json`. One can semi-automate its generation by running:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This pipeline is the WDL equivalent of `lifebit-ai/spammer-nf`.
 Like for `Nextflow` pipelines, one should install `Cromwell` "locally", seperate from the actual pipeline dependencies which will obtained via one or more containers. The installation instructions used to install and run `Cromwell` for the development of this pipeline are as follows:
 
 ```
+# First, ensure Java installed
+# Second, install Cromwelll
 $ cd
 $ mkdir cromwell && cd cromwell
 $ wget https://github.com/broadinstitute/cromwell/releases/download/53.1/cromwell-53.1.jar
@@ -22,7 +24,7 @@ This means `Cromwell` can be called from anywhere using:
 $ java -jar ~/cromwell/cromwell-53.1.jar [specific command]
 ```
 
-Notably, `Cromwell` can also be installed via `conda`.
+Notably, `Cromwell` can also be installed via `conda`. For more details about the different ways to install `Cromwell`, see: https://cromwell.readthedocs.io/en/stable/Getting/.
 
 ## Generate an input.json file
 


### PR DESCRIPTION
## This PR does the following

- It adds basic CI testing for the pipeline
- It adds instructions in the `README.md` file for how to install `Cromwell` and run commands.

## Details:

- The CI testing currently uses a slighlty simplified installation command compared to the one in the `README.md` file, to avoid any folders in the CI test - this may have been causing issues during the initial tests.

- Originally, `java` was explicitely being installed (indeed `java` is a pre-requisite for `Cromwell`) but removed it, after noticing `java` is not explicitely installed in other `Nextflow` pipeline CI tests (does the `ubuntu-latest` have `java` pre-installed?).

## CI testing:

Last successful run: https://github.com/lifebit-ai/spammer-wdl/actions/runs/408790492


 