### PR TITLE
Adds parallelism

### DIFF
--- a/main.wdl
+++ b/main.wdl
@@ -16,19 +16,29 @@ version 1.0
 
 workflow spammer_wdl {
 
-  call task_A
-  call task_B {
-      input:
-      input_file = task_A.output_file_1
-  }
-  call task_C {
-      input:
-      input_file = task_A.output_file_2
-  }
-  call task_D {
-      input:
-      input_file = task_A.output_file_3
-  }
+    input {
+        Int numberRepetitionsFortaskA
+    }
+
+    Array[Int] scatter_range = range(numberRepetitionsFortaskA)
+    
+    scatter(i in scatter_range){
+        call task_A
+        call task_B {
+            input:
+            input_file = task_A.output_file_1
+        }
+        call task_C {
+            input:
+            input_file = task_A.output_file_2
+        }
+        call task_D {
+            input:
+            input_file = task_A.output_file_3
+        }
+
+    }
+
 }
 
 

--- a/main.wdl
+++ b/main.wdl
@@ -68,7 +68,7 @@ task task_A {
         Array[File] output_files = glob("*.txt")
         File output_file_1 = "file_1.txt"
         File output_file_2 = "file_2.txt"
-        File output_file_3 = "file_2.txt"
+        File output_file_3 = "file_3.txt"
     }
 }
 

--- a/options.json
+++ b/options.json
@@ -1,4 +1,5 @@
 {
+    "final_workflow_outputs_dir": "results",
     "default_runtime_attributes": {
         "docker": "quay.io/lifebitai/ubuntu:18.10"
     }

--- a/options.json
+++ b/options.json
@@ -1,6 +1,4 @@
 {
-    "final_workflow_outputs_dir": "results",
-    "use_relative_output_paths": true,
     "default_runtime_attributes": {
         "docker": "quay.io/lifebitai/ubuntu:18.10"
     }

--- a/testdata/inputs.json
+++ b/testdata/inputs.json
@@ -1,4 +1,5 @@
 {
+  "spammer_wdl.numberRepetitionsFortaskA": 10,
   "spammer_wdl.task_A.taskATimeRange": "1-2",
   "spammer_wdl.task_A.numberFilesFortaskA": 3,
   "spammer_wdl.task_A.taskATimeBetweenFileCreationInSecs": 0,


### PR DESCRIPTION
## This PR does the following:

It adds the ability for the pipeline to fully mimic the behavior of `lifebit-ai/spammer-nf`.

## Details:

- Added a `numberRepetitionsFortaskA` param to allow user to chose how many time to repeat `task_A`.

- Implemented an `Array` using `numberRepetitionsFortaskA` and a `scatter` approach. Together, this means that `numberRepetitionsFortaskA` decides how many time `task_A` will be run. Given that `task_B`, `task_C` and `task_D` all take an output of `task_A` as input, if `task_A` runs 10 times, then `task_B`, `task_C` and `task_D` will all run 10 times. too. 

- In order for the outputs from `task_A` (the only task actually producing output files) to not overwrite each other in the `results` folder, had to remove the `use_relative_output_paths": true` settings from `options.json`. This produces a slightly unusual (but accurate folder structure where a `shard` is a unique execution):

<img width="524" alt="Screenshot 2020-12-14 at 18 04 12" src="https://user-images.githubusercontent.com/33165265/102117866-c76e9000-3e36-11eb-9592-1451b086d05d.png">

## Comments:

It might be worth merging all changes into `master` following this PR.

## CI testing:

Successful test: https://github.com/lifebit-ai/spammer-wdl/actions/runs/421410560