### PR TITLE
Adds ability to not need options.json + for now, simplifies output of task_A

### DIFF
--- a/main.wdl
+++ b/main.wdl
@@ -70,6 +70,9 @@ task task_A {
         File output_file_2 = "file_2.txt"
         File output_file_3 = "file_3.txt"
     }
+    runtime {
+        docker: "quay.io/lifebitai/ubuntu:18.10"
+    }
 }
 
 
@@ -91,6 +94,9 @@ task task_B {
     sleep $timeToWait
     dd if=/dev/urandom of=newfile bs=1M count=~{processBWriteToDiskMb}
     >>>
+    runtime {
+        docker: "quay.io/lifebitai/ubuntu:18.10"
+    }
 }
 
 
@@ -110,6 +116,9 @@ task task_C {
     
     sleep $timeToWait
     >>>
+    runtime {
+        docker: "quay.io/lifebitai/ubuntu:18.10"
+    }
 }
 
 
@@ -129,6 +138,9 @@ task task_D {
     
     sleep $timeToWait
     >>>
+    runtime {
+        docker: "quay.io/lifebitai/ubuntu:18.10"
+    }
 }
 
 

--- a/main.wdl
+++ b/main.wdl
@@ -65,7 +65,6 @@ task task_A {
         sleep $timeToWait
     >>>
     output{
-        Array[File] output_files = glob("*.txt")
         File output_file_1 = "file_1.txt"
         File output_file_2 = "file_2.txt"
         File output_file_3 = "file_3.txt"

--- a/options.json
+++ b/options.json
@@ -1,6 +1,3 @@
 {
-    "final_workflow_outputs_dir": "results",
-    "default_runtime_attributes": {
-        "docker": "quay.io/lifebitai/ubuntu:18.10"
-    }
+    "final_workflow_outputs_dir": "results"
 }


### PR DESCRIPTION
# This PR does the following:

- It ability to not need `options.json` (which is produced by CloudOS)
- It simplifies the output of `task_A`.

# Details:

- Removed `docker` settings inside `options.json` and instead added them to each task, in `runtime`. This removes the need for `options.json` to be used when on CloudOS (and works when running the pipeline locally too).

- Simplified the output of `task_A`: now only handles a 3 output files. This allowed the job to run in `CloudOS`. Exact reason remains to be determined. Issue added: https://github.com/lifebit-ai/spammer-wdl/issues/9

# Comments:

- Left both `options.json` and `inputs.json` where they are for now, as they can still be used for local testing.

# CI testing:

https://github.com/lifebit-ai/spammer-wdl/actions/runs/915230709

# GEL CloudOS (integration) testing:

Successful:

![Screenshot 2021-06-07 at 16 02 53](https://user-images.githubusercontent.com/33165265/121040463-d280f800-c7a9-11eb-87e8-06c5eb236f78.png)

